### PR TITLE
vlaslovExample: fix formatting/typo

### DIFF
--- a/source/quickstart/vlasovExample1.rst
+++ b/source/quickstart/vlasovExample1.rst
@@ -278,8 +278,7 @@ Increasing the resolution to :math:`32^2 \times 32^2` and now running the simula
 
   ~/gkylsoft/openmpi/bin/mpirun -n 10 ~/gkylsoft/gkyl/bin/gkyl vm-tsw-2x2v.lua
 
-we obtain the :doc:`following performance <inputFiles/vm-tsw-2x2v-higher-res-log>` with :code:`use
-=true` (note, shared memory is no longer supported) and the installed MPI from the Gkeyll build.
+we obtain the :doc:`following performance <inputFiles/vm-tsw-2x2v-higher-res-log>` with :code:`useShared=true` (note, shared memory is no longer supported) and the installed MPI from the Gkeyll build.
 
 Postprocessing
 --------------


### PR DESCRIPTION
In PR #3 `shared` was accidentally replaced with a newline character which resulted in the sentence rendering as:
<img width="757" alt="Screen Shot 2022-10-19 at 1 41 51 PM" src="https://user-images.githubusercontent.com/1024438/196766329-ffcb0c58-2924-48ae-8d42-5bee540841fb.png">
This PR fixes it; sorry for the noise.
