### PR TITLE
Fixes a link to the 10-moment example

### DIFF
--- a/source/gkyl/App/Moment/Moments.rst
+++ b/source/gkyl/App/Moment/Moments.rst
@@ -89,7 +89,7 @@ Examples
 --------
 
 - :doc:`Five-moment modeling of the GEM challenge magnetic reconnection problem.<rt-5m-gem>`
-- :doc:`Ten-moment modeling of the GEM challenge magnetic reconnection problem.<rt-5m-gem>` This simulation uses a simplified closure appropriate for this problem.
+- :doc:`Ten-moment modeling of the GEM challenge magnetic reconnection problem.<rt-10m-gem>` This simulation uses a simplified closure appropriate for this problem.
 
 Basic parameters
 ----------------


### PR DESCRIPTION
On https://gkeyll.readthedocs.io/en/latest/gkyl/App/Moment/Moments.html, there was a link that incorrectly linked to the 5-moment lua script instead of the 10-moment script it said it linked to. This fixes that, and now the ten-moment script is accessible.