### PR TITLE
Issue and PR templates

### DIFF
--- a/source/dev/main.rst
+++ b/source/dev/main.rst
@@ -4,7 +4,8 @@ Developer notes
 .. toctree::
   :maxdepth: 1
 
-  dev-rules             
+  dev-rules     
+  suggested-templates        
   onmaxima
   modalbasis
   recovery

--- a/source/dev/suggested-templates.rst
+++ b/source/dev/suggested-templates.rst
@@ -199,7 +199,7 @@ Bug fix
 
   - [ ] I added a regression test to test this feature.
   - [ ] I added this feature to an existing regression test.
-  - [ ] I added a unit test to test this feature. A file added to `/zero` must have an associated unit test.
+  - [ ] I added a unit test to test this feature. A file or function added to `/zero` must have an associated unit test.
   - [ ] I modified an `/app` file and tested it by ensuring that the outputs were reasonable by eye.
   - [ ] Ran `make check` and unit tests all pass.
   - [ ] I ran the code through Valgrind, and it is clean.
@@ -254,7 +254,7 @@ Feature addition
 
   - [ ] I added a regression test to test this feature.
   - [ ] I added this feature to an existing regression test.
-  - [ ] I added a unit test to test this feature. A file added to `/zero` must have an associated unit test.
+  - [ ] I added a unit test to test this feature. A file or function added to `/zero` must have an associated unit test.
   - [ ] I modified an `/app` file and tested it by ensuring that the outputs were reasonable by eye.
   - [ ] Ran `make check` and unit tests all pass.
   - [ ] I ran the code through Valgrind, and it is clean.

--- a/source/dev/suggested-templates.rst
+++ b/source/dev/suggested-templates.rst
@@ -263,3 +263,42 @@ Feature addition
   ## Additional Notes
 
   _Include any additional context, caveats, or future improvements related to the feature._
+
+Documentation changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: markdown
+  
+  # Documentation Changes
+
+  _Italicized text may be removed for final submission_
+
+  # Purpose
+
+  _What does this update address?_
+
+  _Briefly describe the reason for the documentation update (new information, improve clarity, fix errors, update deprecated content, etc.)._
+
+  # Affected Areas
+
+  _Which part of the documentation is being updated?_
+
+  _List the files, sections, or components of the documentation that are affected by this update (e.g., API reference, installation guide, tutorial, etc.)._
+
+  # Changes Made
+
+  _List and describe the specific changes made to the documentation._
+
+  # Reason for Change
+
+  _Explain why these changes were necessary or how they improve the documentation._
+
+  # Additional Notes
+
+  _Include any relevant information that might help reviewers, such as why certain phrasing was used or how the changes relate to new functionality or bug fixes._
+
+  # Checklist _(x (yes), blank (no))_
+  - [ ] I have reviewed the documentation for accuracy.
+  - [ ] All technical terms and code examples have been double-checked.
+  - [ ] The update aligns with the overall style and tone of the documentation.
+  - [ ] The updated documentation builds correctly (if applicable).

--- a/source/dev/suggested-templates.rst
+++ b/source/dev/suggested-templates.rst
@@ -199,8 +199,9 @@ Bug fix
 
   - [ ] I added a regression test to test this feature.
   - [ ] I added this feature to an existing regression test.
-  - [ ] I added a unit test to test this feature. A file or function added to `/zero` must have an associated unit test.
-  - [ ] I modified an `/app` file and tested it by ensuring that the outputs were reasonable by eye.
+  - [ ] I added a unit test to test this feature.
+  - [ ] I modified/added a function or file to `/zero`, which should have an associated unit test.
+  - [ ] I modified/added a function or file to `/app` and tested it to ensure the outputs were correct.
   - [ ] Ran `make check` and unit tests all pass.
   - [ ] I ran the code through Valgrind, and it is clean.
   - [ ] I ran a few regression tests to ensure no apparent errors.
@@ -254,8 +255,9 @@ Feature addition
 
   - [ ] I added a regression test to test this feature.
   - [ ] I added this feature to an existing regression test.
-  - [ ] I added a unit test to test this feature. A file or function added to `/zero` must have an associated unit test.
-  - [ ] I modified an `/app` file and tested it by ensuring that the outputs were reasonable by eye.
+  - [ ] I added a unit test to test this feature.
+  - [ ] I modified/added a function or file to `/zero`, which should have an associated unit test.
+  - [ ] I modified/added a function or file to `/app` and tested it to ensure the outputs were correct.
   - [ ] Ran `make check` and unit tests all pass.
   - [ ] I ran the code through Valgrind, and it is clean.
   - [ ] I ran a few regression tests to ensure no apparent errors.

--- a/source/dev/suggested-templates.rst
+++ b/source/dev/suggested-templates.rst
@@ -190,18 +190,19 @@ Bug fix
 
   Impacted files: _List the components, files, or modules impacted by the fix._
 
+  Automated testing: _Please explain how the feature was tested. If no automated tests are included (e.g. unit, regression), explain why._
+
   ## Community Standards
 
   - [ ] Documentation has been updated.
   - [ ] My code follows the project's coding guidelines.
+  - [ ] Changes to `/zero` should have a unit test.
 
   ## Testing: _(x (yes), blank (no))_
 
   - [ ] I added a regression test to test this feature.
   - [ ] I added this feature to an existing regression test.
-  - [ ] I added a unit test to test this feature.
-  - [ ] I modified/added a function or file to `/zero`, which should have an associated unit test.
-  - [ ] I modified/added a function or file to `/app` and tested it to ensure the outputs were correct.
+  - [ ] I added a unit test for this feature.
   - [ ] Ran `make check` and unit tests all pass.
   - [ ] I ran the code through Valgrind, and it is clean.
   - [ ] I ran a few regression tests to ensure no apparent errors.
@@ -238,6 +239,8 @@ Feature addition
 
   Dependencies: _If any, mention any new configuration changes, libraries, or dependencies added._
 
+  Automated testing: _Please explain how the feature was tested. If no automated tests are included (e.g. unit, regression), explain why._
+
   ## Example Use
 
   _Provide some example code of how a user may utilize this new feature in an input file._
@@ -250,14 +253,13 @@ Feature addition
 
   - [ ] Documentation has been updated.
   - [ ] My code follows the project's coding guidelines.
+  - [ ] Changes to `/zero` should have a unit test.
 
   ## Testing: _(x (yes), blank (no))_
 
   - [ ] I added a regression test to test this feature.
   - [ ] I added this feature to an existing regression test.
   - [ ] I added a unit test to test this feature.
-  - [ ] I modified/added a function or file to `/zero`, which should have an associated unit test.
-  - [ ] I modified/added a function or file to `/app` and tested it to ensure the outputs were correct.
   - [ ] Ran `make check` and unit tests all pass.
   - [ ] I ran the code through Valgrind, and it is clean.
   - [ ] I ran a few regression tests to ensure no apparent errors.
@@ -297,11 +299,11 @@ Documentation changes
 
   # Reason for Change
 
-  _Explain why these changes were necessary or how they improve the documentation._
+  _Explain why these changes were necessary or how they improved the documentation._
 
   # Additional Notes
 
-  _Include any relevant information that might help reviewers, such as why certain phrasing was used or how the changes relate to new functionality or bug fixes._
+  _Include relevant information that might help reviewers, such as why certain phrasing was used or how the changes relate to new functionality or bug fixes._
 
   # Checklist _(x (yes), blank (no))_
   - [ ] I have reviewed the documentation for accuracy.

--- a/source/dev/suggested-templates.rst
+++ b/source/dev/suggested-templates.rst
@@ -197,8 +197,10 @@ Bug fix
 
   ## Testing: _(x (yes), blank (no))_
 
-  - [ ] I added a regression test to test for this bug.
-  - [ ] I added a unit test to test this bug.
+  - [ ] I added a regression test to test this feature.
+  - [ ] I added this feature to an existing regression test.
+  - [ ] I added a unit test to test this feature. A file added to `/zero` must have an associated unit test.
+  - [ ] I modified an `/app` file and tested it by ensuring that the outputs were reasonable by eye.
   - [ ] Ran `make check` and unit tests all pass.
   - [ ] I ran the code through Valgrind, and it is clean.
   - [ ] I ran a few regression tests to ensure no apparent errors.
@@ -251,7 +253,9 @@ Feature addition
   ## Testing: _(x (yes), blank (no))_
 
   - [ ] I added a regression test to test this feature.
-  - [ ] I added a unit test to test this feature.
+  - [ ] I added this feature to an existing regression test.
+  - [ ] I added a unit test to test this feature. A file added to `/zero` must have an associated unit test.
+  - [ ] I modified an `/app` file and tested it by ensuring that the outputs were reasonable by eye.
   - [ ] Ran `make check` and unit tests all pass.
   - [ ] I ran the code through Valgrind, and it is clean.
   - [ ] I ran a few regression tests to ensure no apparent errors.

--- a/source/dev/suggested-templates.rst
+++ b/source/dev/suggested-templates.rst
@@ -1,0 +1,265 @@
+.. _suggestedTemplates:
+
+Suggested templates for issues and pull requests to Gkeyll
+=======================================================================================
+
+When creating an issue or pull request, we highly reccomend using the following templates to ensure that the issue is addressed in a timely manner.
+Templates are a great way to standardize the review process and ensure complience with the project's guidelines.
+
+Issues
+-----------------------
+
+Bug report
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: markdown
+
+  # Bug Report
+
+  _Italicized text may be removed for final submission_
+
+  ## Summary:
+
+  _A brief description of the issue._
+
+  ## Steps to Reproduce:
+
+  _Provide a clear, step-by-step guide to reproduce the issue._
+
+  1. _Step 1._
+  2. _Step 2._
+
+  ## Expected Behavior:
+
+  _Describe what you expected to happen._
+
+  ## Actual Behavior:
+
+  _Describe what happened, including error messages or incorrect output._
+
+  ## Environment:
+
+  _Provide details of the environment where the issue occurred_
+
+  - System / Cluster Name: 
+  - Branch name: 
+  - GPU or CPU build: 
+  - Operating System:
+  - Loaded modules:
+  - Code version: (e.g. commit hash):
+
+  ## Additional Context:
+
+  _Any other details or comments that might help us diagnose the issue._
+
+  _Did the issue occur after a recent update or change?_
+
+  _Are there specific parameters or inputs that seem to trigger the bug?_
+
+  _Screenshots, logs, or output files (if applicable)_
+
+  ## Suggested Fix (Optional):
+
+  _If you have an idea for a fix, describe it here._
+
+
+
+Design review
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: markdown 
+
+  # Design Review
+
+  _Italicized text may be removed for final submission_
+
+  ## Overview
+
+  Description: _Provide a brief overview of the feature or change. Explain its purpose, scope, and intended outcome._
+
+  Motivation: _Why is this feature or change needed? What problem does it solve, or what improvement does it bring to Gkeyll?_
+
+  Impact: _Outline the expected impact on the codebase, including affected areas (e.g., /apps, /zero, Lua/G2 layer). Specify if there will be breaking changes or dependencies on other components._
+
+  ## Proposed Design
+
+  Key Design Elements: _Describe the key aspects of your proposed design. Use concise language to outline the algorithms, user-facing APIs, and architectural choices._
+
+  Interaction with Existing Code: _Explain how this change will integrate with the current codebase. Highlight any architectural or convention clashes and areas that might require future refactoring._
+
+  Prototyping Efforts (if applicable): _Provide a link to your prototyping branch. Briefly summarize your findings from prototyping, including any adjustments made to the design._
+
+  Sample Code:
+  ``` 
+  Include example input file fragments, unit tests, regression tests, or mock APIs to will help reviewers understand how the proposed feature will be used and tested.
+  ```
+
+  ## Design Review Checklist _(x (yes), blank (no))_
+
+  Approval Criteria: 
+
+  - [ ] Is the design coherent and consistent with Gkeyll's existing architecture?
+  - [ ] Does the design align with user-facing API standards?
+  - [ ] Do functionalities overlap with existing features?
+  - [ ] Are the algorithms robust and appropriate for the intended purpose?
+
+  ## Additional Notes
+
+  Future Considerations: _Are there any anticipated challenges or areas of concern in implementing this design?_
+
+  Feedback Integration Plan: _Outline how you will address feedback received during the design review process._
+
+  ## Links
+
+  Prototyping Branch: _Link to prototyping branch_
+
+  Relevant Documentation: _Links to LaTeX files or working notes_
+
+  Additional Resources: 
+
+Feature request
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: markdown
+
+  # Feature Request
+
+  _Italicized text may be removed for final submission_
+
+  ## Summary
+
+  Overview: _What problem does this feature address? Clearly describe the problem or limitation that this feature would solve._
+
+  Proposed solution: _Outline the proposed solution and how it addresses the problem._
+
+  ## Feature Details
+
+  Key functionality: _Describe the specific functionality of the feature._
+
+  Scope: _Indicate the scope of the feature (e.g., minor enhancement, major overhaul, etc.)._
+  User Stories/Use Cases:
+
+  Example: _Provide examples of how the end-user would use this feature._
+
+  ```
+  Example code snips can improve clarity to the reviewer
+  ```
+
+  ## Benifits
+
+  _Explain the benefits of implementing this feature._
+
+  _How does it improve the user experience, efficiency, or codebase?_
+
+  ## Considerations
+
+  _Describe any known challenges, risks, or dependencies that might impact development._
+
+  _List any alternative solutions and why they were not chosen._
+
+  ## Additional Information
+
+  _Include any relevant diagrams, mockups, screenshots, or resources (if applicable)._
+
+  ## Checklist _(x (yes), blank (no))_
+
+  - [ ] This feature has not already been implemented or requested.
+  - [ ] I have reviewed related issues and discussions to avoid duplication.
+
+Pull requests
+--------------------
+
+Bug fix
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: markdown
+
+  # Bug fix
+
+  _Italicized text may be removed for final submission_
+
+  ## Summary
+
+  Description: _Describe the bug in a sentence or two. What was the root cause?_
+
+  Issue link: _A link to the issue._
+
+  ## Solution
+
+  _Explain how the bug was fixed. Highlight the changes made to the code and why they address the issue._
+
+  Impacted files: _List the components, files, or modules impacted by the fix._
+
+  ## Community Standards
+
+  - [ ] Documentation has been updated.
+  - [ ] My code follows the project's coding guidelines.
+
+  ## Testing: _(x (yes), blank (no))_
+
+  - [ ] I added a regression test to test for this bug.
+  - [ ] I added a unit test to test this bug.
+  - [ ] Ran `make check` and unit tests all pass.
+  - [ ] I ran the code through Valgrind, and it is clean.
+  - [ ] I ran a few regression tests to ensure no apparent errors.
+  - [ ] Tested and works on CPU.
+  - [ ] Tested and works on multi-CPU.
+  - [ ] Tested and works on GPU.
+  - [ ] Tested and works on multi-GPU.
+
+  ## Additional Notes
+
+  _Include any additional context, related PRs, or future considerations related to this bug fix._
+
+
+Feature addition
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: markdown
+
+  # Feature
+
+  _Italicized text may be removed for final submission_
+
+  ## Summary
+
+  Purpose: _Explain the feature and why it is being added._
+
+  Issue link: _Link to the related issue or feature request_
+
+  ## Implementation Details
+
+  Key changes: _List the key changes made to the codebase to implement the feature._
+
+  _Describe any new components, classes, or modules introduced._
+
+  Dependencies: _If any, mention any new configuration changes, libraries, or dependencies added._
+
+  ## Example Use
+
+  _Provide some example code of how a user may utilize this new feature in an input file._
+
+  ```
+  example code
+  ```
+
+  ## Community Standards
+
+  - [ ] Documentation has been updated.
+  - [ ] My code follows the project's coding guidelines.
+
+  ## Testing: _(x (yes), blank (no))_
+
+  - [ ] I added a regression test to test this feature.
+  - [ ] I added a unit test to test this feature.
+  - [ ] Ran `make check` and unit tests all pass.
+  - [ ] I ran the code through Valgrind, and it is clean.
+  - [ ] I ran a few regression tests to ensure no apparent errors.
+  - [ ] Tested and works on CPU.
+  - [ ] Tested and works on multi-CPU.
+  - [ ] Tested and works on GPU.
+  - [ ] Tested and works on multi-GPU.
+
+  ## Additional Notes
+
+  _Include any additional context, caveats, or future improvements related to the feature._


### PR DESCRIPTION
# Documentation Changes

# Purpose

Having a template for our issues and pull requests promotes adherence to our community standards. It creates an efficient review process and standardizes the procedure for changing the code. Testing will not be forgotten when creating pull requests because submitters will confront their lack of rigorous testing head-on. I, as well as others, have been very guilty of pushing code to shared branches that break other people's code which would have been avoided by propper testing.

I discussed with Jonathan Gorard how the files should be structured. We aim to not have documentation in the gkylzero / gkyl repository. This should be in the gkyl-docs repository. We should be linking to the docs repository and having a central template over there. The easiest way to do this is with a link that submitters can follow, provided by a small template in the repo. There is a small template in this repo, but the main details, the meat of the hamburger, are on the docs repo. This is associated with a PR in that repo as well.

# Affected Areas

The templates for creating issues and pull requests.

We add a developer note with all the templates in one file, then link to them from the gkyl code repositories

# Changes Made

Files are added.

# Reason for Change

Templates for issues and pull requests promote adherence to community standards. 

# Additional Notes

Ironically, I am unable to test these features as they need to be on main for them to be considered by GitHub. I tested the use of the templates with this pull request, which is the documentation update template.

I ran these files through Grammarly to ensure proper English usage.

I compiled the webpage locally. There were some issues with having this page show up when clicked on another sub-article under developer notes. I have reason to believe that this issue will be resolved when the page is re-released with this information. I noticed other pages were being ignored by the search.

I would like a first-pass merge because I would like to make the final commit in the gkylzero repo that links to this page without having to do an amendment later. Getting the URL means merging this first.

# Checklist (x)
- [x] I have reviewed the documentation for accuracy.
- [x] All technical terms and code examples have been double-checked.
- [x] The update aligns with the overall style and tone of the documentation.
- [x] The updated documentation builds correctly (if applicable).