### PR TITLE
Fix latex not compiling on all pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the documentation and tutorials for the
 
 In order to build the docs locally, one needs
 [sphinx](https://www.sphinx-doc.org/en/master/) and the
-[immaterial](https://jbms.github.io/sphinx-immaterial/) theme.
+[furo](https://github.com/pradyunsg/furo) theme.
 
 We recommend creating a virtual environment[^1] and installing the dependencies
 through [conda](https://conda.io/miniconda.html):

--- a/source/conf.py
+++ b/source/conf.py
@@ -117,6 +117,12 @@ html_static_path = ['_static', 'postgkyl/_static']
 #      }
 html_css_files = ['theme_overrides.css']  # override wide tables in RTD theme
 
+# Force MathJax to load on every page by adding it to every page's scripts
+html_js_files = [
+  ('https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js', 
+  {'async': 'async'}),
+]
+
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.


### PR DESCRIPTION
Fix an issue where latex was not compiling on all pages. To fix, we have to add the html file to the javascript on each page in the conf.py file. The readme is also updated for the dependency on furo rather than the old sphinx immaterial theme

Before
<img width="2982" height="2616" alt="image" src="https://github.com/user-attachments/assets/d2f872e1-6f69-4bcc-a918-b1143766cb3b" />


After
<img width="2982" height="2616" alt="image" src="https://github.com/user-attachments/assets/0ecca67f-aa15-4d86-b0a9-366527c08448" />
