### PR TITLE
Update clone URL on Install page in another place

### DIFF
--- a/source/install.rst
+++ b/source/install.rst
@@ -30,7 +30,7 @@ from GitHub (`which can be found here <https://github.com/gkeyllorg/gkeyll>`_):
 
 .. code-block:: bash
 
-  git clone https://github.com/ammarhakim/gkeyll.git
+  git clone https://github.com/gkeyllorg/gkeyll.git
 
 and then, once it has been cloned, to navigate into the ``gkeyll`` directory:
 


### PR DESCRIPTION
Missed the updated clone link in another place before; fixed now.